### PR TITLE
Execute the Feedback service under a dedicated non-root user account

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 FROM openjdk:11-jdk-slim
 ARG jar
+RUN groupadd -g 986 censusfeedbacksvc && \
+     useradd -r -u 986 -g censusfeedbacksvc censusfeedbacksvc
+USER censusfeedbacksvc
 COPY $jar /opt/censusfeedbacksvc.jar
 ENV JAVA_OPTS=""
 ENTRYPOINT [ "java",  "-jar", "/opt/censusfeedbacksvc.jar" ]


### PR DESCRIPTION
# Motivation and Context
The principle of using least privilege should be followed when executing code within containers. Specifically, not running as root.

# What has changed
The Dockerfile has been changed:

* Create a dedicated non-root user account for executing the Java code

# How to test?
I tested this change by creating a differently tagged Docker image and deploying to my Kubernetes cluster. I verified that:

* The pod started successfully
* The Kubernetes readiness and liveness probes succeeded
* There were no errors in the container logs
* `exec`-ing into the container showed the Java process running as the expected non-root user account